### PR TITLE
fix(client): fix stream abruptly closed error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2018"
 [dependencies]
 tokio = { version = "1.15", features = ["full"] }
 chatgpt_rs = { version = "1.2.3", features = ["streams"] }
-dirs = "3.0.2"
-futures-util = "0.3"
+dirs = "5.0.1"
+futures-util = "0.3.30"
 futures = "0.3"
-shellexpand = "1.0"
+shellexpand = "3.1.0"
 
 [[bin]]
 name = "chatgpt_cli"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 
 [dependencies]
 tokio = { version = "1.15", features = ["full"] }
-chatgpt_rs = { version = "1.1.11", features = ["streams"] }
+chatgpt_rs = { version = "1.2.3", features = ["streams"] }
 dirs = "3.0.2"
 futures-util = "0.3"
 futures = "0.3"

--- a/src/client.rs
+++ b/src/client.rs
@@ -2,9 +2,6 @@ use chatgpt::prelude::*;
 use super::file;
 use std::io::{stdout, Write};
 use futures_util::StreamExt;
-use chatgpt::types::{CompletionResponse};
-
-// Publicly setable ChatGPTEngine
 
 pub async fn get_client(key: String, engine: ChatGPTEngine) -> ChatGPT {
     let config = ModelConfigurationBuilder::default()
@@ -12,11 +9,10 @@ pub async fn get_client(key: String, engine: ChatGPTEngine) -> ChatGPT {
         .build()
         .unwrap();
 
-    let client = match ChatGPT::new_with_config(&key, config) {
+    match ChatGPT::new_with_config(key, config) {
         Ok(val) => val,
         Err(err) => panic!("Failed to create ChatGPT client: {}", err),
-    };
-    return client;
+    }
 }
 
 pub async fn process_message(client: &ChatGPT, message: &str) -> chatgpt::Result<()> {

--- a/src/client.rs
+++ b/src/client.rs
@@ -2,6 +2,7 @@ use chatgpt::prelude::*;
 use super::file;
 use std::io::{stdout, Write};
 use futures_util::StreamExt;
+use chatgpt::types::{CompletionResponse};
 
 // Publicly setable ChatGPTEngine
 
@@ -19,6 +20,7 @@ pub async fn get_client(key: String, engine: ChatGPTEngine) -> ChatGPT {
 }
 
 pub async fn process_message(client: &ChatGPT, message: &str) -> chatgpt::Result<()> {
+    // You can later read this conversation history again
     let mut conversation = if std::path::Path::new(&file::main_conversation_file()).exists() {
         client
             .restore_conversation_json(file::main_conversation_file())
@@ -27,36 +29,38 @@ pub async fn process_message(client: &ChatGPT, message: &str) -> chatgpt::Result
         client.new_conversation()
     };
 
-    let mut stream = conversation
-        .send_message_streaming(message.to_string())
-        .await?;
+    // Acquiring a streamed response
+// Note, that the `futures_util` crate is required for most
+// stream related utility methods
+let mut stream = conversation
+    .send_message_streaming(message.to_string())
+    .await?;
 
-    let mut output: Vec<ResponseChunk> = Vec::new();
-    while let Some(chunk) = stream.next().await {
-        match chunk {
-            ResponseChunk::Content {
+    // Iterating over a stream and collecting the results into a vector
+let mut output: Vec<ResponseChunk> = Vec::new();
+while let Some(chunk) = stream.next().await {
+    match chunk {
+        ResponseChunk::Content {
+            delta,
+            response_index,
+        } => {
+            // Printing part of response without the newline
+            print!("{delta}");
+            // Manually flushing the standard output, as `print` macro does not do that
+            stdout().lock().flush().unwrap();
+            output.push(ResponseChunk::Content {
                 delta,
                 response_index,
-            } => {
-                // Printing part of response without the newline
-                print!("{delta}");
-                // Manually flushing the standard output, as `print` macro does not do that
-                stdout().lock().flush().unwrap();
-                output.push(ResponseChunk::Content {
-                    delta,
-                    response_index,
-                });
-            }
-            // We don't really care about other types, other than parsing them into a ChatMessage later
-            other => output.push(other),
+            });
         }
+        // We don't really care about other types, other than parsing them into a ChatMessage later
+        other => output.push(other),
     }
+}
 
     // Parsing ChatMessage from the response chunks and saving it to the conversation history
     let messages = ChatMessage::from_response_chunks(output);
-    conversation.history.extend(messages);
-    // conversation.history.push(messages[0].to_owned());
-
+    conversation.history.push(messages[0].to_owned());
     conversation
         .save_history_json(file::main_conversation_file())
         .await?;

--- a/src/file.rs
+++ b/src/file.rs
@@ -9,7 +9,7 @@ pub fn get_data_dir(app_name: &str) -> Option<PathBuf> {
 }
 
 pub fn conversations_dir() -> Option<PathBuf> {
-    return get_data_dir(APP_NAME);
+    get_data_dir(APP_NAME)
 }
 
 pub fn main_conversation_file() -> String {
@@ -18,5 +18,5 @@ pub fn main_conversation_file() -> String {
 
 pub fn conversation_file_path(name: &str) -> Option<PathBuf> {
     let conversions_dir = conversations_dir()?;
-    Some(PathBuf::from(conversions_dir).join(format!("conversation_{}.json", name)))
+    Some(conversions_dir.join(format!("conversation_{}.json", name)))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,9 @@ async fn main() -> chatgpt::Result<()> {
         args_vec.retain(|x| x != "--gpt35");
     }
 
-    let client = client::get_client(client_key, engine).await;
+    // let client = client::get_client(client_key, engine).await;
+
+    let client = ChatGPT::new(client_key)?;
 
     std::fs::create_dir_all(file::conversations_dir().unwrap())?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -302,7 +302,7 @@ async fn message_with_file(
             )
             .await?;
 
-            for (result) in result.iter() {
+            for result in result.iter() {
                 results.push(result.message().content.clone());
             }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,7 +43,7 @@ async fn main() -> chatgpt::Result<()> {
 
 
     // If there are any arguments, use them as the message
-    let message = if args_vec.len() > 0 {
+    let message = if !args_vec.is_empty() {
         Some(args_vec.join(" "))
     } else {
         None
@@ -61,7 +61,7 @@ async fn main() -> chatgpt::Result<()> {
         input
     };
 
-    let first_command = input.trim().split_whitespace().next().unwrap();
+    let first_command = input.split_whitespace().next().unwrap();
     // remove the potential command from the arguments
     // in process_message we will just use the raw input
     let args_vec: Vec<String> = args_vec.into_iter().skip(1).collect();
@@ -111,7 +111,7 @@ async fn main() -> chatgpt::Result<()> {
 }
 
 async fn save_conversation(client: &ChatGPT, args: &[String]) -> chatgpt::Result<()> {
-    let file_name = if let Some(name) = args.get(0) {
+    let file_name = if let Some(name) = args.first() {
         println!("Saving conversation as {}", name);
         file::conversation_file_path(name).unwrap()
     } else {
@@ -132,7 +132,7 @@ async fn save_conversation(client: &ChatGPT, args: &[String]) -> chatgpt::Result
 }
 
 async fn remove_conversation(args: &[String]) -> chatgpt::Result<()> {
-    let file_name = if let Some(name) = args.get(0) {
+    let file_name = if let Some(name) = args.first() {
         println!("Removing conversation {}", name);
         file::conversation_file_path(name).unwrap()
     } else {
@@ -150,7 +150,7 @@ async fn remove_conversation(args: &[String]) -> chatgpt::Result<()> {
 }
 
 async fn load_conversation(client: &ChatGPT, args: &[String]) -> chatgpt::Result<()> {
-    let file_name = if let Some(name) = args.get(0) {
+    let file_name = if let Some(name) = args.first() {
         println!("Loading conversation from {}", name);
         file::conversation_file_path(name).unwrap()
     } else {
@@ -234,7 +234,7 @@ async fn message_with_file(
     client: &ChatGPT,
     key: &str,
     engine: ChatGPTEngine,
-    args: &String,
+    args: &str,
 ) -> chatgpt::Result<()> {
     let file_name = args
         .split_whitespace()
@@ -294,16 +294,15 @@ async fn message_with_file(
 
         // Send each chunk in batched_chunks to the AI in sequence
         while let Some(chunk) = batched_chunks.first() {
-            let key = key.clone();
             let result = ai::process_chunks(
                 key.to_string(),
                 engine,
-                (*message.clone()).to_string(),
+                (*message).to_string(),
                 chunk.to_vec(),
             )
             .await?;
 
-            for (_index, result) in result.iter().enumerate() {
+            for (result) in result.iter() {
                 results.push(result.message().content.clone());
             }
 


### PR DESCRIPTION

```
.cargo/registry/src/index.crates.io-6f17d22bba15001f/chatgpt_rs-1.2.3/./src/client.rs:301:39:
Stream closed abruptly!: Transport(reqwest::Error { kind: Body, source: TimedOut })
stack backtrace:
   0: _rust_begin_unwind
   1: core::panicking::panic_fmt
   2: core::result::unwrap_failed
   3: <T as futures_util::fns::FnMut1<A>>::call_mut
   4: chatgpt_cli::client::process_message::{{closure}}
   5: chatgpt_cli::main::{{closure}}
   6: tokio::runtime::park::CachedParkThread::block_on
   7: tokio::runtime::context::runtime::enter_runtime
   8: tokio::runtime::runtime::Runtime::block_on
   9: chatgpt_cli::main
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```